### PR TITLE
Feat/elegation notification handler

### DIFF
--- a/src/keria/app/delegating.py
+++ b/src/keria/app/delegating.py
@@ -43,7 +43,7 @@ class Sealer(doing.DoDoer):
 
         # load the hab of the delegated identifier to anchor
         hab = self.hby.habs[pre]
-        delpre = hab.kever.delegator  # get the delegator identifier
+        delpre = hab.kever.delpre  # get the delegator identifier
         if delpre not in hab.kevers:
             raise kering.ValidationError(f"delegator {delpre} not found, unable to process delegation")
 
@@ -128,7 +128,7 @@ class Sealer(doing.DoDoer):
         """
         for (pre, said), serder in self.hby.db.dune.getItemIter():  # group partial witness escrow
             kever = self.hby.kevers[pre]
-            dkever = self.hby.kevers[kever.delegator]
+            dkever = self.hby.kevers[kever.delpre]
 
             seal = dict(i=serder.pre, s=serder.snh, d=serder.said)
             if dserder := self.hby.db.findAnchoringSealEvent(dkever.prefixer.qb64, seal=seal):


### PR DESCRIPTION
## Context:
 
When another wallet delegates to us, we should receive a notification to prompt the UI to accept/ignore the delegation request.

## Changes:

Add a exchange message handler to KERIA that listens for delegation request messages so we know if someone is trying to delegate their AID to ours

## Ticket:
[KERIA DELEGATION HANDLER](https://cardanofoundation.atlassian.net/browse/DTIS-502)